### PR TITLE
DE-3322: make insertions/upserts in mongoflink exactly once

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,14 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>decodable-mvn-snapshots-local</id>
+            <name>decodable-mvn-snapshots-local</name>
+            <url>https://decodable-671293015970.d.codeartifact.us-west-2.amazonaws.com/maven/decodable-mvn-snapshots-local/</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>decodable-mvn-releases-local</id>
+            <name>decodable-mvn-releases-local</name>
+            <url>https://decodable-671293015970.d.codeartifact.us-west-2.amazonaws.com/maven/decodable-mvn-releases-local/</url>
         </repository>
     </distributionManagement>
 
@@ -311,6 +313,30 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>decodable-mvn-releases-local</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>decodable-mvn-releases-local</id>
+                    <url>https://decodable-671293015970.d.codeartifact.us-west-2.amazonaws.com/maven/decodable-mvn-releases-local/</url>
+                </repository>
+            </repositories>
+        </profile>
+        <profile>
+            <id>decodable-mvn-snapshots-local</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>decodable-mvn-snapshots-local</id>
+                    <url>https://decodable-671293015970.d.codeartifact.us-west-2.amazonaws.com/maven/decodable-mvn-snapshots-local/</url>
+                </repository>
+            </repositories>
         </profile>
     </profiles>
 </project>

--- a/src/main/java/org/mongoflink/sink/MongoCommitter.java
+++ b/src/main/java/org/mongoflink/sink/MongoCommitter.java
@@ -1,10 +1,10 @@
 package org.mongoflink.sink;
 
-import com.mongodb.*;
 import org.mongoflink.internal.connection.MongoClientProvider;
 
 import org.apache.flink.api.connector.sink.Committer;
 
+import com.mongodb.*;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 /**
  * MongoCommitter flushes data to MongoDB in a transaction. Due to MVCC implementation of MongoDB, a
@@ -63,7 +62,6 @@ public class MongoCommitter implements Committer<DocumentBulk> {
     public List<DocumentBulk> commit(List<DocumentBulk> committables) throws IOException {
         List<DocumentBulk> failedBulk = new ArrayList<>();
 
-        int rand = new Random().nextInt(10 - 1 + 1) + 1;
         for (DocumentBulk bulk : committables) {
             if (bulk.getDocuments().size() > 0) {
                 CommittableTransaction transaction;
@@ -75,39 +73,37 @@ public class MongoCommitter implements Committer<DocumentBulk> {
                     transaction = new CommittableTransaction(collection, bulk.getDocuments());
                 }
                 try {
-//                    // test 1
-//                    if (rand == 1) {
-//                        System.out.println("***** TEST 1 *****");
-//                        throw new IOException("test 1");
-//                    }
-
                     int insertedDocs = session.withTransaction(transaction, txnOptions);
-
-                    // test 2
-                    if (rand == 2) {
-                        System.out.println("***** TEST 2 *****");
-                        throw new IOException("test 2");
-                    }
 
                     LOGGER.info(
                             "Inserted {} documents into collection {}.",
                             insertedDocs,
                             collection.getNamespace());
                 } catch (MongoBulkWriteException e) {
-                    // ignore duplicate key errors in case txn was already committed but client was not aware of it
+                    // for insertions, ignore duplicate key errors in case txn was already committed
+                    // but client was not aware of it
+
+                    // NOTE: upserts are idempotent in mongo, so no exceptions need to be caught for
+                    // redundant upserts
                     for (WriteError err : e.getWriteErrors()) {
                         if (err.getCode() != DUPLICATE_KEY_ERROR_CODE) {
                             LOGGER.error("Failed to commit with Mongo transaction.", e);
                             failedBulk.add(bulk);
+                        } else {
+                            LOGGER.error(String.format("write error here: %s", err.getMessage()));
                         }
-                        // TODO: catch other write errors
                     }
                     LOGGER.warn("Ignoring duplicate records");
                 } catch (Exception e) {
                     // save to a new list that would be retried
-                    LOGGER.error("Failed to commit with Mongo transaction.", e);
+                    LOGGER.error(
+                            String.format(
+                                    "Failed to commit with Mongo transaction – requeueing %d records",
+                                    bulk.size()),
+                            e);
                     failedBulk.add(bulk);
                 }
+                // TODO: [DE-3303] if needed, catch duplicate delete errors
             }
         }
         return failedBulk;

--- a/src/main/java/org/mongoflink/sink/MongoCommitter.java
+++ b/src/main/java/org/mongoflink/sink/MongoCommitter.java
@@ -97,8 +97,10 @@ public class MongoCommitter implements Committer<DocumentBulk> {
                     // ignore duplicate key errors in case txn was already committed but client was not aware of it
                     for (WriteError err : e.getWriteErrors()) {
                         if (err.getCode() != DUPLICATE_KEY_ERROR_CODE) {
-                            throw e;
+                            LOGGER.error("Failed to commit with Mongo transaction.", e);
+                            failedBulk.add(bulk);
                         }
+                        // TODO: catch other write errors
                     }
                     LOGGER.warn("Ignoring duplicate records");
                 } catch (Exception e) {


### PR DESCRIPTION
Approach: enforce per-record idempotence to achieve exactly-once behavior

- for insertions: catch duplicate key errors and ignore them
- for upserts: upserts are already idempotent in mongodb

validation -> package mongoflink locally with the following changes:
- insert a crash before commit with 33% prob (test 1)
- insert a crash after commit with 33% prob (test 2)
- run the sink, observe

run the validation as follows: 

in upsert mode
[ ] run crash tests individually
[ ] run crash tests together

in append mode
[ ] run crash tests individually
[ ] run crash tests together